### PR TITLE
Reas_PTU.py: support additional encoding for tyAnsiString

### DIFF
--- a/PTU/Python/Read_PTU.py
+++ b/PTU/Python/Read_PTU.py
@@ -129,7 +129,11 @@ while True:
         tagDataList.append((evalName, tagTime))
     elif tagTyp == tyAnsiString:
         tagInt = struct.unpack("<q", inputfile.read(8))[0]
-        tagString = inputfile.read(tagInt).decode("utf-8").strip("\0")
+        tmp_bytes = inputfile.read(tagInt)
+        try:
+            tagString = tmp_bytes.decode('utf-8').strip("\0")
+        except UnicodeDecodeError:
+            tagString = tmp_bytes.decode('latin1','ignore').strip("\0")
         outputfile.write("%s" % tagString)
         tagDataList.append((evalName, tagString))
     elif tagTyp == tyWideString:


### PR DESCRIPTION
Sometimes you find characters in tyAnsiString, e.g. in File_Comment, that are latin1 encoded and not valid utf-8 (most notoriously the 'µ' character. Now we try 'latin1' if 'utf-8' decoding fails. Additionally, we make the code more robust by ignoring errors in the second attempt at decoding.
